### PR TITLE
improve ZP session auth and retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unversioned Changes (next version)
 
-* (none)
+* [Issue 1](https://github.com/rally25rs/zwift-api-wrapper/issues/1) : Improve ZwiftPower auth and session timeout. Retry request once if first attempt seems to fail due to an expired session cookie.
 
 # v0.0.7
 

--- a/src/zwiftApi.ts
+++ b/src/zwiftApi.ts
@@ -317,7 +317,7 @@ export class ZwiftAPI extends BaseApi {
     return await this.fetchJSON<ZwiftGameInfo>(`/api/game_info`, { apiVersion: "2.7" });
   }
 
-  async searchProfiles(searchText: string, options = {}) {
+  async searchProfiles(searchText: string, options = {}) { // missed the return type here
     return await this.fetchPaged("/api/search/profiles", {
       method: "POST",
       json: { query: searchText },
@@ -339,7 +339,7 @@ export class ZwiftAPI extends BaseApi {
     );
   }
 
-  async setFollowing(them: string | number, us: string | number) {
+  async setFollowing(them: string | number, us: string | number) { // missed return type here
     return await this.fetchJSON(`/api/profiles/${us}/following/${them}`, {
       method: "POST",
       json: {


### PR DESCRIPTION
improves #1 

It seems that there are always valid and unexpired cookies whether you are logged in or not. However `phpbb3_lswlk_u` gets set to `1` in the response if the session timed out. So we can check for `1` after the HTTP response to see if the request 'failed'. This depends on the endpoint though. Some routes that return HTML will return HTTP 200 and the HTML for the login. Some endpoints that return JSON will return 403 and an error message.
So with this change the library now checks for a `401` or `403` response, or if the `_u` cookie is set to `1` after the response, and does 1 retry and re-authentication before erroring.